### PR TITLE
Ensure hostnames/subdomains with dots in them are displayed correctly

### DIFF
--- a/namesilo.php
+++ b/namesilo.php
@@ -180,11 +180,8 @@ function namesilo_transactionCall($callType, $call, $params)
                 if ($code == '300') {
                     foreach ($xml->reply->resource_record as $record) {
                         $hostname = (string)$record->host;
-                        if ($hostname == $params['sld'] . "." . $params['tld']) {
-                            $hostname = '';
-                        }
-                        $hostname = explode(".", $hostname);
-                        $hostname = (string)$hostname[0];
+                        $hostname = str_replace($params['sld'] . "." . $params['tld'], "", $hostname);
+                        $hostname = rtrim($hostname, ".");
                         $response[] = array("hostname" => $hostname, "type" => $record->type, "address" => $record->value, "record_id" => $record->record_id, "priority" => $record->distance);
                     }
                     break;


### PR DESCRIPTION
This ensures that subdomains of subdomains aren't cut off with just deepest subdomain showing. Example: test.test.domain.com would only show test when it should show test.test in WHMCS

The most common use case for this now, is DKIM records which frequently look like:
default._domainkey.theactualdomain.tld

which would show as just 'default' in WHMCS until this patch.