### PR TITLE
Do not return cancelled if the domain isn't active

### DIFF
--- a/namesilo.php
+++ b/namesilo.php
@@ -1399,14 +1399,16 @@ function namesilo_Sync($params)
         }
 
         $status = (string)$result->status;
-        $active = $status === 'Active' ? true : false;
 
-        return [
-            'active' => $active,
-            'cancelled' => !$active,
-            'transferredAway' => false,
-            'expirydate' => (string)$result->expires,
-        ];
+        if ($status === 'Active'){
+            return [
+                'active' => true,
+                'expirydate' => (string)$result->expires,
+            ];
+        }
+        else{
+            return ['active' => false ]; //expired
+        }
 
     } catch (\Throwable $e) {
         return ['error' => 'ERROR: ' . $domainName . ' - ' . $e->getMessage()];


### PR DESCRIPTION
This allows WHMCS to handle statuses from the various stages of expiry, like expired, expired grace, etc.
Note: the $code === 200 conditional on line 1380 handles the truly necessary cases to force a cancelled status.
Fixes #3